### PR TITLE
Date parsing that is looser and stricter.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject schema-contrib "0.1.4"
+(defproject schema-contrib "0.1.5"
   :description "Additional validators for Prismatic's Schema."
   :url "https://github.com/sfx/schema-contrib"
   :license {:name "Eclipse Public License"

--- a/resources/date.abnf
+++ b/resources/date.abnf
@@ -1,13 +1,29 @@
 ; http://www.ietf.org/rfc/rfc3339.txt
+; and http://www.odata.org/documentation/odata-version-3-0/abnf/
+
+oneToNine = "01" / "02" / "03" / "04" / "05" / "06" / "07" / "08" / "09"
+zeroToNine = "00" / oneToNine
+
+oneToTwelve = oneToNine / "1" ( "0" / "1" / "2" )
+
+oneToThirteen = oneToTwelve / "13"
+
+zeroToFiftyNine = zeroToNine / ( "1" / "2" / "3" / "4" / "5" ) DIGIT
+
+zeroToSixty = zeroToNine / ( "1" / "2" / "3" / "4" / "5" ) DIGIT / "60"
+
+oneToThirtyOne = oneToNine / ( "1" / "2" ) DIGIT / "30" / "31"
+
+zeroToTwentyFour = zeroToNine / "1" DIGIT / "2" ( "0" / "1" / "2" / "3" / "4" )
 
 date-century    = 2DIGIT  ; 00-99
 date-decade     =  DIGIT  ; 0-9
 date-subdecade  =  DIGIT  ; 0-9
 date-year       = date-decade date-subdecade
 date-fullyear   = date-century date-year
-date-month      = 2DIGIT  ; 01-12
-date-wday       =  DIGIT  ; 1-7  ; 1 is Monday, 7 is Sunday
-date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+date-month      = oneToTwelve  ; 01-12
+date-wday       = DIGIT  ; 1-7  ; 1 is Monday, 7 is Sunday
+date-mday       = oneToThirtyOne  ; 01-28, 01-29, 01-30, 01-31 based on
                          ; month/year
 date-yday       = 3DIGIT  ; 001-365, 001-366 based on year
 date-week       = 2DIGIT  ; 01-52, 01-53 based on year
@@ -35,10 +51,10 @@ date              = datespec-full / datespec-year
                    / datespec-month /
 datespec-mday / datespec-week / datespec-wday / datespec-yday
 
-time-hour         = 2DIGIT ; 00-24
-time-minute       = 2DIGIT ; 00-59
-time-second       = 2DIGIT ; 00-58, 00-59, 00-60 based on
-                          ; leap-second rules
+time-hour         = zeroToTwentyFour ; 00-24
+time-minute       = zeroToFiftyNine ; 00-59
+time-second       = zeroToSixty ; 00-58, 00-59, 00-60 based on
+                                ; leap-second rules
 time-fraction     = ("," / ".") 1*DIGIT
 time-numoffset    = ("+" / "-") time-hour [[":"] time-minute]
 time-zone         = "Z" / time-numoffset
@@ -53,7 +69,9 @@ timespec-base     = timespec-hour / timespec-minute / timespec-second
 
 time              = timespec-base [time-fraction] [time-zone]
 
-iso-date-time     = date "T" time
+date-time-sep     = "T" / SP
+
+iso-date-time     = date date-time-sep time
 
 dur-second        = 1*DIGIT "S"
 dur-minute        = 1*DIGIT "M" [dur-second]

--- a/resources/date.abnf
+++ b/resources/date.abnf
@@ -56,7 +56,7 @@ time-minute       = zeroToFiftyNine ; 00-59
 time-second       = zeroToSixty ; 00-58, 00-59, 00-60 based on
                                 ; leap-second rules
 time-fraction     = ("," / ".") 1*DIGIT
-time-numoffset    = ("+" / "-") time-hour [[":"] time-minute]
+time-numoffset    = 0*1SP ("+" / "-") time-hour [[":"] time-minute]
 time-zone         = "Z" / time-numoffset
 
 timeopt-hour      = "-" / (time-hour [":"])

--- a/test/schema_contrib/core_test.clj
+++ b/test/schema_contrib/core_test.clj
@@ -90,11 +90,33 @@
   (is (invalid Language-Keyword "en")))
 
 (deftest iso-date-time-test
-  (is (valid ISO-Date-Time "2014-04-01T20:17:35+00:00"))
+  (is (valid ISO-Date-Time "2014-04-01T22:17:35+02:00"))
   (is (valid ISO-Date-Time "2014-04-01T20:17:35Z"))
-  (is (valid ISO-Date-Time "2007-04-05T14:30"))
+  (is (valid ISO-Date-Time "2007-04-05T14:59"))
   (is (valid ISO-Date-Time "2007-04-05T14:30Z"))
   (is (valid ISO-Date-Time "2007-04-05T12:30-02:00"))
+
+  (is (valid ISO-Date-Time "2014-04-01 20:17:35+00:00"))
+  (is (valid ISO-Date-Time "2014-04-01 21:17:35Z"))
+  (is (valid ISO-Date-Time "2007-04-05 14:30"))
+  (is (valid ISO-Date-Time "2007-04-05 14:30Z"))
+  (is (valid ISO-Date-Time "2007-04-05 12:30-02:00"))
+
+  (is (not (valid ISO-Date-Time "2007-13-05T12:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-12-45T12:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05T25:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05T12:61-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05T12:30-25:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05T12:30-02:61")))
+
+  (is (not (valid ISO-Date-Time "2007-13-05 12:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-12-45 12:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05 25:30-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05 12:61-02:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05 12:30-25:00")))
+  (is (not (valid ISO-Date-Time "2007-01-05 12:30-02:61")))
+
+
   (is (invalid ISO-Date-Time "2014-04-01"))
   (is (invalid ISO-Date-Time "2014-W14"))
   (is (invalid ISO-Date-Time "2014-W14-2"))
@@ -134,4 +156,3 @@
 (deftest uri-reference-test
   (doall (map #(is (valid URI-Reference %)) absolute-uris))
   (doall (map #(is (valid URI-Reference %)) uri-references)))
-


### PR DESCRIPTION
It allows for a space between date and time in addition to T as
suggested in the text of the RFC.

It also limits months, days of the month, hours, minutes and seconds to
reasonable numbers. It doesn't yet try to parse things, but it keeps the
strings closer to real ISO Date Times.
