### PR TITLE
update to latest deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/sfx/schema-contrib"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[instaparse "1.3.0"]
+  :dependencies [[instaparse "1.3.5"]
                  [org.clojure/clojure "1.6.0"]
-                 [org.clojure/test.check "0.5.7"]
-                 [prismatic/schema "0.2.6"]]
+                 [org.clojure/test.check "0.7.0"]
+                 [prismatic/schema "0.3.7"]]
   :resource-paths ["resources"])


### PR DESCRIPTION
Beyond keeping dependencies up to date, there's a known error with instaparse < 1.3.4 that causes issues with Clojure 1.7. Thanks!
